### PR TITLE
Fixed the link for manual in FAQ page

### DIFF
--- a/public/faq.md
+++ b/public/faq.md
@@ -68,7 +68,7 @@
 
 - Will I receive a certificate at the end of the KWoC?
 
-  If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our [manual](https://drive.google.com/file/d/1Bq_1tEgjBZo7g2Pi-BWuHsiCIc3aYRMe/view)
+  If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our [manual](https://drive.google.com/file/d/1Bq_1tEgjBZo7g2Pi-BWuHsiCIc3aYRMe/view).
 
 - Which programming language(s) do I need to be fluent in?
 

--- a/public/faq.md
+++ b/public/faq.md
@@ -68,7 +68,7 @@
 
 - Will I receive a certificate at the end of the KWoC?
 
-  If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our [manual](link here)
+  If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our [manual](https://drive.google.com/file/d/1Bq_1tEgjBZo7g2Pi-BWuHsiCIc3aYRMe/view)
 
 - Which programming language(s) do I need to be fluent in?
 

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -101,7 +101,7 @@
   {
     "q": "Will I receive a certificate at the end of the KWoC?",
     "a": [
-      "If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our [manual](link here)"
+      "If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our [manual](https://drive.google.com/file/d/1Bq_1tEgjBZo7g2Pi-BWuHsiCIc3aYRMe/view)"
     ]
   },
   {

--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -101,7 +101,7 @@
   {
     "q": "Will I receive a certificate at the end of the KWoC?",
     "a": [
-      "If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our [manual](https://drive.google.com/file/d/1Bq_1tEgjBZo7g2Pi-BWuHsiCIc3aYRMe/view)"
+      "If you remain with us till the end of the program, then you'll receive a certificate for completion of the program. You would have to clear both the mid and end evaluation to get the certificate. More details can be found in our <a href='https://drive.google.com/file/d/1Bq_1tEgjBZo7g2Pi-BWuHsiCIc3aYRMe/view'>manual</a>."
     ]
   },
   {


### PR DESCRIPTION
The link for student manual which was earlier not clickable, has been added. Students will now be able to navigate easily through the FAQs to the required document