### PR TITLE
Remove negative days from dashboard

### DIFF
--- a/src/views/MentorDashboard.js
+++ b/src/views/MentorDashboard.js
@@ -152,7 +152,12 @@ export default function MentorDashboard() {
                   {moment("07-12-2022", "DD-MM-YYYY").diff(
                     moment.now(),
                     "days"
-                  )}
+                  ) > 0
+                    ? moment("07-12-2022", "DD-MM-YYYY").diff(
+                        moment.now(),
+                        "days"
+                      )
+                    : 0}
                 </h2>
                 <p>Days to go</p>
               </div>

--- a/src/views/StudentDashboard.js
+++ b/src/views/StudentDashboard.js
@@ -163,7 +163,12 @@ export default function StudentDashboard() {
                   {moment("07-12-2022", "DD-MM-YYYY").diff(
                     moment.now(),
                     "days"
-                  )}
+                  ) > 0
+                    ? moment("07-12-2022", "DD-MM-YYYY").diff(
+                        moment.now(),
+                        "days"
+                      )
+                    : 0}
                 </h2>
                 <p>Days to go</p>
               </div>


### PR DESCRIPTION
This commit removes the negative days from the dashboard, both student as well as mentor. This is done by checking if the days are negative and if so, setting them to 0.