### PR TITLE
docs: fix incorrect start command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Hi :wave: there, welcome to KWoC React project. We are glad that you considered 
 
 First install all the dependencies using pnpm (:warning: not npm​) by running `$ pnpm` in the root directory.
 
-Everything including building and serving locally is pre-configured in the `package.json` file. You can run the command `$pnpm start` to start a live server.
+Everything including building and serving locally is pre-configured in the `package.json` file. You can run the command `$pnpm dev` to start a live server.
 
 ## Workspace Setup
 


### PR DESCRIPTION
Hi team,

I noticed a small error in the CONTRIBUTING.md file. The instructions mentioned running pnpm start, but package.json does not have a "start" script; it uses pnpm dev (Vite).

I have updated the command to prevent errors for new contributors.

Thanks!