### PR TITLE
fix: add minimum 3 tags validation (#177)

### DIFF
--- a/src/pages/ProjectForm.tsx
+++ b/src/pages/ProjectForm.tsx
@@ -123,6 +123,22 @@ function ProjectForm(props: { isEditing?: boolean }) {
             setError(null);
             setInfo(null);
 
+            // Ensure minimum 3 tags when tags are provided
+            const tagsArray =
+              responses.tags
+                ? responses.tags
+                    .split(",")
+                    .map((t) => t.trim())
+                    .filter((t) => t.length > 0)
+                : [];
+
+            if (tagsArray.length > 0 && tagsArray.length < 3) {
+              setError(
+                "Minimum 3 tags required! (e.g: javascript, html, css)",
+              );
+              return false;
+            }
+
             try {
               setLoading(true);
               const res = await makeRequest(
@@ -132,9 +148,13 @@ function ProjectForm(props: { isEditing?: boolean }) {
                   ...responses,
                   secondary_mentor_username:
                     responses.secondary_mentor_username ?? "",
-                  tags: responses.tags !== "" ? responses.tags.split(",") : [],
+                  tags: tagsArray,
                   mentor_username: authContext.userData.username,
-                  id: isEditing ? (id ? parseInt(id) : undefined) : undefined,
+                  id: isEditing
+                    ? id
+                      ? parseInt(id)
+                      : undefined
+                    : undefined,
                 },
                 authContext.jwt,
               );
@@ -154,7 +174,6 @@ function ProjectForm(props: { isEditing?: boolean }) {
               console.log(e);
               setError("An unexpected error occurred.");
               setLoading(false);
-
               return false;
             }
           }}


### PR DESCRIPTION
Fixes #177

## Changes
- Added minimum 3 tags validation in `ProjectForm.tsx` before project submission.
- Validates that the tags field contains at least 3 non-empty, comma-separated tags when provided.
- Reuses a cleaned `tagsArray` both for validation and for sending tags to the backend.

## Testing
- Tested with 1 tag: shows "Minimum 3 tags required! (e.g: javascript, html, css)" and blocks submission. 
- Tested with 3+ tags (e.g. `javascript, html, css`): passes validation and proceeds to submit. 

## Details
This validation ensures project submissions have sufficient tags for better categorization and discoverability.